### PR TITLE
docs: update release tracking for 0.58.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Codex CLIを使うためのメモ集。
 ## リポジトリ
 
 - GitHub: https://github.com/openai/codex
-- 調査した最新バージョンは`0.57.0`です(2025/11/13)
+- 調査した最新バージョンは`0.58.0`です(2025/11/13)
 
 ## OpenAI 公式サイト（Codex/CLI）
 

--- a/reports/2025-11-13-0-58-0.md
+++ b/reports/2025-11-13-0-58-0.md
@@ -1,0 +1,14 @@
+## 追加された機能・設定項目
+
+- `codex app-server` サブコマンドに `generate-ts` と `generate-json-schema` を追加し、CLI からアプリサーバープロトコルの TypeScript／JSON Schema 出力を生成できるようになった。
+- macOS 向け `codex debug sandbox seatbelt` に子プロセス追跡と拒否ログ収集を行う `DenialLogger` が加わり、サンドボックス拒否を対話的に洗い出せるようになった。
+- TUI の更新アクション検出を新しい `update_action` モジュールへ切り出し、npm／bun／Homebrew でのインストール形態に応じた更新コマンドを自動提案できるようになった。
+
+## 廃止された(または廃止予定の)機能・設定項目
+
+- 旧 `codex protocol generate-ts` サブコマンドと `codex-rs/protocol-ts` クレートが削除され、アプリサーバーツールに統合された。
+
+## その他
+
+- TUI に新しいサスペンド制御 (`tui::job_control`) が追加され、SIGTSTP 後のオルタネートスクリーン復元やカーソル位置調整が自動化された。
+- Thread 再開 API (`ThreadResumeParams`) が履歴／パス指定や設定オーバーライドに対応し、クラウドとの連携時に柔軟な再開フローを構成できるようになった。


### PR DESCRIPTION
## Summary
- update the README to note codex 0.58.0 as the latest reviewed version
- add a 2025-11-13 release report summarizing new CLI tooling, sandbox logging, and TUI updates

## Testing
- not run (not applicable)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6917f88c31188327bc6c1e4735943108)