### PR TITLE
Clarify timing of web_search deprecation in 0.58.0 report

### DIFF
--- a/reports/2025-11-13-0-58-0.md
+++ b/reports/2025-11-13-0-58-0.md
@@ -7,6 +7,7 @@
 ## 廃止された(または廃止予定の)機能・設定項目
 
 - 旧 `codex protocol generate-ts` サブコマンドと `codex-rs/protocol-ts` クレートが削除され、アプリサーバーツールに統合された。
+- `config.toml` の `[tools]` セクションで `web_search` を有効化する手順が 0.58.0 から非推奨となり、`features.web_search_request` フラグに移行するよう通知された（0.57.0 ではまだ非推奨化されていなかった）。
 
 ## その他
 


### PR DESCRIPTION
## Summary
- clarify that the `[tools].web_search` deprecation notice applies starting in 0.58.0 and was not yet present in 0.57.0

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6917fce1fa3c8327b0f38b809a0a19a4)